### PR TITLE
docs: add canonical AGENTS.md for agent-based contributors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,91 @@
+# AGENTS.md
+
+Instructions for AI coding agents working in this repository.
+
+## Project Purpose
+
+Agentflow provides reusable skills for AI coding agents (Claude Code, Codex, and others). Skills are self-contained instruction sets that agents invoke to perform structured workflows.
+
+## Repo Structure
+
+```
+install.sh                          # Installs skills via symlinks
+skills/
+  planning-meeting/SKILL.md         # Collaborative planning skill
+  execute-plan-task/SKILL.md        # Task execution skill
+templates/
+  plan-output.md                    # Plan document template
+.gitignore                          # Excludes plans and artifacts
+```
+
+## How Skills Work
+
+Each skill is a directory under `skills/` containing a `SKILL.md` file. The `SKILL.md` uses YAML frontmatter with two required fields:
+
+```yaml
+---
+name: skill-name
+description: When and how the skill triggers.
+---
+```
+
+The body of `SKILL.md` contains the full instructions the agent follows when the skill is invoked.
+
+### Installation
+
+Run `./install.sh` to symlink all skills into the agent-specific directories:
+
+- Claude Code: `~/.claude/skills/<skill-name>`
+- Codex: `~/.agents/skills/<skill-name>`
+
+The installer validates that each skill directory exists and its `SKILL.md` has the required `name:` frontmatter before creating symlinks.
+
+## Workflow: Planning then Execution
+
+Agentflow uses a two-phase workflow:
+
+1. **planning-meeting** -- Conduct a collaborative planning session that produces a plan document with small, stacked tasks. Plans are written to `.agentflow/plans/YYYY-MM-DD-<feature-name>.md` in the target project.
+
+2. **execute-plan-task** -- Execute one task from a plan through a multi-agent workflow (implement, review, test, document) and create a PR. Invoke once per task, in dependency order.
+
+## Plans and Artifacts
+
+Plans and execution artifacts are local working state, not committed to version control.
+
+- **Plans:** `.agentflow/plans/` (gitignored)
+- **Artifacts:** `.agentflow/artifacts/` (gitignored)
+
+These directories exist in the target project where skills are invoked, not in this repo.
+
+## Development Principles
+
+This project follows trunk-based development:
+
+- One logical change per commit/PR
+- Small diffs, reviewable in roughly 15 minutes
+- All PRs target `main`
+- No long-lived feature branches
+
+## Adding a New Skill
+
+1. Create a directory under `skills/` with the skill name (lowercase, hyphenated).
+2. Add a `SKILL.md` with YAML frontmatter (`name:` and `description:`) and the skill instructions in the body.
+3. Add the skill name to the `SKILLS` array in `install.sh`.
+4. Run `./install.sh` to verify it installs correctly.
+
+## Modifying an Existing Skill
+
+Edit the `SKILL.md` directly. Since installation uses symlinks, changes take effect immediately for any agent using the installed skill. No reinstall is needed.
+
+## Templates
+
+Shared templates live in `templates/`. Skills reference these templates by convention. Currently:
+
+- `templates/plan-output.md` -- Structure for plan documents produced by `planning-meeting`.
+
+## Things to Avoid
+
+- Do not commit plan files or execution artifacts to this repo.
+- Do not add user-specific paths or configuration.
+- Do not add private or internal-only references.
+- Keep skill instructions self-contained within their `SKILL.md`.


### PR DESCRIPTION
## Summary

Adds `AGENTS.md` at the repository root as the canonical set of instructions for AI coding agents working in this repository. The file provides orientation to the repo structure, skill conventions, the two-phase workflow (planning → execution), and development principles — all in under 100 lines of concise, actionable content.

## Changes

- **`AGENTS.md` (new)** — 91-line file covering: project purpose, repo structure, how skills work (SKILL.md convention, installation via install.sh), the planning-meeting → execute-plan-task workflow, plans/artifacts as local working state, trunk-based development principles, how to add/modify skills, and content to avoid.

## Decisions

- **Concise over comprehensive:** Kept under 100 lines. Agents work best with dense, actionable content rather than verbose documentation.
- **No duplication of SKILL.md content:** AGENTS.md provides orientation and conventions; detailed skill instructions remain in their respective SKILL.md files.
- **Canonical source for CLAUDE.md:** Designed to be the single source of truth that a future CLAUDE.md wrapper will reference (Task 3 dependency).
- **Explicit target-project distinction:** Calls out that `.agentflow/` directories exist in target projects where skills are invoked, not in this repo.

## Verification

- **Reviewer:** PASS — All 7 filesystem paths verified against actual repo. YAML frontmatter claims match both SKILL.md files. install.sh behavior accurately described. No private/sensitive content found. Diff is clean (single new file, no modifications).
- **Tester:** PASS — File exists (91 lines, 3302 bytes). Valid markdown structure. `./install.sh` runs successfully (exit 0, no regressions). All path claims verified. Symlinks confirmed working. No test suite exists; validation limited to install.sh and manual checks.

## Artifacts

The following artifacts are available locally (gitignored) for detailed review:
- `.agentflow/artifacts/2026-02-27-add-canonical-agents-instructions/adr.md` — Architecture decisions
- `.agentflow/artifacts/2026-02-27-add-canonical-agents-instructions/implementation-report.md` — Implementation details
- `.agentflow/artifacts/2026-02-27-add-canonical-agents-instructions/architecture-diagram.txt` — Component diagram
- `.agentflow/artifacts/2026-02-27-add-canonical-agents-instructions/verification.md` — Full verification record

## Status

This PR was created automatically by the `execute-plan-task` skill.
**Awaiting human review and merge approval.**

Source plan: `.agentflow/plans/2026-02-28-documentation-baseline-no-ci.md`
Task: Task 2 — Add Canonical AGENTS Instructions