### PR TITLE
infra: define GitHub Issue task schema and status labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,62 @@
+name: Task
+description: An executable task from an agentflow plan. Parseable by automation.
+labels: ["status:todo"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What this task accomplishes.
+      placeholder: Describe the task in concrete terms.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: How we know this task is done. Each criterion on its own line.
+      placeholder: |
+        - [ ] Criterion 1
+        - [ ] Criterion 2
+    validations:
+      required: true
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: |
+        Issues that must be completed before this task can start.
+        Use the format: `#<number>` for each dependency, comma-separated.
+        Example: `#1, #3`
+        Write `None` if there are no dependencies.
+      placeholder: "None"
+    validations:
+      required: true
+
+  - type: textarea
+    id: files-likely-affected
+    attributes:
+      label: Files Likely Affected
+      description: List of files or directories this task will likely touch.
+      placeholder: |
+        - `src/foo.ts`
+        - `tests/foo.test.ts`
+    validations:
+      required: true
+
+  - type: dropdown
+    id: layer
+    attributes:
+      label: Layer
+      description: The architectural layer this task primarily operates in.
+      options:
+        - data
+        - api
+        - ui
+        - test
+        - infra
+        - docs
+    validations:
+      required: true

--- a/templates/plan-output.md
+++ b/templates/plan-output.md
@@ -17,14 +17,31 @@
 
 ## Tasks
 
-### Task 1: [Name]
-- **Description:** What this task accomplishes
-- **Acceptance Criteria:** How we know it's done
-- **Dependencies:** What must land before this
-- **Files likely affected:** [list]
-- **Layer:** data / api / ui / test / infra
+Tasks are tracked as GitHub Issues using the `task` issue template.
+Each task issue includes: Description, Acceptance Criteria, Dependencies, Files Likely Affected, and Layer.
 
-### Task 2: [Name]
+### Status Labels
+
+| Label | Meaning |
+|-------|---------|
+| `status:todo` | Task is defined but not yet started |
+| `status:in-progress` | Task is actively being worked on |
+| `status:blocked` | Task cannot proceed (dependency unmet or other blocker) |
+
+### Dependency Encoding
+
+Dependencies between tasks are encoded in each issue's **Dependencies** field
+using GitHub issue references: `#<number>`, comma-separated.
+
+Example: `#1, #3` means the task depends on issues #1 and #3 being completed first.
+`None` means the task has no dependencies.
+
+### Task List
+
+| Task | Issue | Status | Dependencies |
+|------|-------|--------|--------------|
+| Task 1: [Name] | #TBD | `status:todo` | None |
+| Task 2: [Name] | #TBD | `status:todo` | #TBD |
 ...
 
 ## Open Questions


### PR DESCRIPTION
## Summary

This task introduced a GitHub Issue-based task tracking system for agentflow plans. A YAML form template was created to standardize how tasks are filed as GitHub Issues with five parseable fields. Three status labels were created on the repository to track task lifecycle. The plan output template was updated to document the new GitHub Issues workflow, replacing the previous inline task format.

## Changes

- **`.github/ISSUE_TEMPLATE/task.yml`** (new) — GitHub issue form template named "Task" with five required fields: Description (textarea), Acceptance Criteria (textarea), Dependencies (textarea), Files Likely Affected (textarea), and Layer (dropdown: data/api/ui/test/infra/docs). Auto-applies `status:todo` label on creation.
- **`templates/plan-output.md`** (modified) — Replaced inline task definition format with GitHub Issues-based workflow documentation: status labels table, dependency encoding section, and task list table format.
- **GitHub labels** (created via API) — `status:todo` (green), `status:in-progress` (yellow), `status:blocked` (red).

## Architecture

```
[NEW] .github/ISSUE_TEMPLATE/task.yml
    |
    |-- defines schema for --> GitHub Issues (task type)
    |                              |
    |                              |-- auto-applies --> [NEW] Label: status:todo
    |                              |-- transitioned to --> [NEW] Label: status:in-progress
    |                              |-- transitioned to --> [NEW] Label: status:blocked
    |                              |
    |                              |-- Dependencies field encodes --> Issue references (#N)
    |                              |       |
    |                              |       +-- parsed by --> Automation / Agents
    |                              |                          (dependency graph resolution)
    |                              |
    |                              +-- Layer field categorizes --> data | api | ui | test | infra | docs
    |
    +-- referenced by --> [MODIFIED] templates/plan-output.md
                              |
                              |-- documents --> Status label convention
                              |-- documents --> Dependency encoding format
                              |-- documents --> Task list table format
                              |
                              +-- used by --> .agentflow/plans/*.md (plan files)
                                                  |
                                                  +-- read by --> execute-plan-task skill
                                                                    |
                                                                    +-- creates issues from --> task.yml template

Component Legend:
  [NEW]      = Added by this task
  [MODIFIED] = Changed by this task
  (no tag)   = Existing component shown for context
```

## Decisions

### Issue Template Format: YAML Form Template (`task.yml`)

Chose GitHub's YAML-based issue form template over Markdown-based templates. YAML form templates provide structured fields with enforced types, built-in validation (`required: true`), and machine-parseable field IDs. Markdown templates were rejected due to lack of structured field IDs and fragile regex parsing requirements.

### Dependency Encoding: GitHub Issue References

Dependencies are encoded as comma-separated GitHub issue references (`#1, #3`) with `None` as the sentinel for no dependencies. This format is native to GitHub (auto-links), simple to parse with regex (`#(\d+)`), and immediately understandable to humans and automation. Task list checkbox syntax (`- [ ] #1`) was rejected as it conflates completion tracking with dependency declaration.

### Status Labels: Namespaced with `status:` Prefix

Three labels with `status:` namespace prefix prevent collision with other label taxonomies (e.g., `priority:`, `layer:`) and enable predictable queries via `gh label list --search "status:"`. Labels without namespace prefix were rejected due to higher collision risk.

### Layer Options: Addition of `docs`

The Layer dropdown includes `docs` in addition to the five layers from the original plan (data, api, ui, test, infra). This supports documentation-only tasks common in agentflow workflows.

## Verification

### Review: PASS
- All 3 acceptance criteria independently verified by reviewer
- No regressions, no security concerns, clean diff
- YAML validated against GitHub issue form spec
- Minor note: `docs` layer addition deemed reasonable

### Testing: PASS
- YAML syntax validation — PASS (valid YAML, correct structure)
- GitHub issue template spec conformance — PASS (all fields valid types, unique IDs, required attributes)
- `gh label list` — PASS (all 3 labels confirmed on repo with correct colors/descriptions)
- Dependency encoding parsing — PASS (6/6 test cases: `None`, `#1`, `#1, #3`, `#12`, `#1, #2, #3, #10`, `#1,#2`)
- No automated test suite in repo; all validation via parsing, API checks, and spec conformance

### Iterations
No iterations required. All gates passed on first cycle.

### Limitations
- No CI configured; no automated test suite runs against these files
- End-to-end form submission rendering not tested (spec conformance only)
- Dependency regex parsing tested ad-hoc, not in a persistent test suite

---
This PR was created automatically by the `execute-plan-task` skill.
Source plan: `.agentflow/plans/2026-02-28-github-issues-only-task-orchestration.md` | Task: 1 — Define GitHub Issue Task Schema and Status Convention